### PR TITLE
Create nginx log dir and file on startup

### DIFF
--- a/nginx.run
+++ b/nginx.run
@@ -16,5 +16,9 @@ then
   rm $PIDFILE
 fi
 
+# In case the log dir is not there
+mkdir -p /var/log/nginx
+touch /var/log/nginx/error.log
+
 /usr/sbin/nginx -t
 exec /usr/sbin/nginx


### PR DESCRIPTION
Keeps nginx from failing to start if volume is mounted to /var/log inside the contianers.

Fixes #28 

Signed-off-by: Christopher Collins <collins.christopher@gmail.com>