### PR TITLE
making chnctl.py +x, adding usage if run with no args, linking to PATH

### DIFF
--- a/chnctl.py
+++ b/chnctl.py
@@ -9,6 +9,7 @@ from flask_security.utils import encrypt_password
 from mhn.auth.models import User
 from mhn import mhn, db
 import argparse
+import sys
 
 parser = argparse.ArgumentParser(description="CHN Server CLI Tool")
 parser.add_argument('-u',
@@ -19,8 +20,10 @@ parser.add_argument('-p',
                     dest='password',
                     required=True,
                     help='password')
-
-args = parser.parse_args()
+if len(sys.argv)==1:
+    parser.print_help()
+    sys.exit(1)
+args=parser.parse_args()
 
 with mhn.test_request_context():
     try:

--- a/chnserver.yml
+++ b/chnserver.yml
@@ -160,3 +160,12 @@
         command: "gunzip {{ server_dir }}/GeoIPASNum.dat.gz"
         args:
           creates: "{{ server_dir }}/GeoIPASNum.dat"
+
+      - name: CHN Server | link chnctl.py to bindir
+        file:
+          src: /opt/chnctl.py
+          dest: /usr/local/bin/chnctl
+          owner: root
+          group: root
+          state: link
+


### PR DESCRIPTION
Signed-off-by: Christopher Collins <collins.christopher@gmail.com>

Allows chnctl.py to be executed by with:

$dockercmd exec chnctl -u user -p password

Adds help text if executed w/o args