### PR TITLE
Add volume mount to hold state file

### DIFF
--- a/scripts/deploy_dionaea.sh
+++ b/scripts/deploy_dionaea.sh
@@ -13,6 +13,7 @@ services:
     volumes:
       - ./dionaea.sysconfig:/etc/default/dionaea
       - ./dionaea/services-available/:/opt/dionaea/etc/dionaea/services-enabled/
+      - ./dionaea/dionaea:/etc/dionaea/
     ports:
       - "21:21"
       - "23:23"


### PR DESCRIPTION
The docker-compose.yml file created by the default deployment script did not create a volume to hold the registration state for the honeypot. This commit fixes that issue.