### PR TITLE
In which our hero regretfully disables HSTS option

### DIFF
--- a/nginx_vhost.conf
+++ b/nginx_vhost.conf
@@ -35,7 +35,7 @@ server {
     ssl_prefer_server_ciphers on;
 
     # HSTS (ngx_http_headers_module is required) (15768000 seconds = 6 months)
-    add_header Strict-Transport-Security max-age=15768000;
+    # add_header Strict-Transport-Security max-age=15768000;
 
     # OCSP Stapling ---
     # fetch OCSP records from URL in ssl_certificate and cache them


### PR DESCRIPTION
…so that connections can occur in cases where Let'sEncrypt deployment fails and it's necessary to fall back to the self-signed cert.

Signed-off-by: Jesse Bowling <jesse.bowling@duke.edu>