### PR TITLE
Adding in some basic functional tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 TODO
 *.swp
+.pytest_cache/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -86,6 +86,17 @@ sast:
   artifacts:
     paths: [gl-license-management-report.json]
 
+infra_testing:
+  image: docker:stable
+  stage: integration_testing
+  allow_failure: true
+  services:
+    - docker:stable-dind
+  tags:
+    - container_scanning
+  script:
+    - sudo py.test .
+
 container_scanning:
   image: docker:stable
   stage: integration_testing

--- a/chnserver.yml
+++ b/chnserver.yml
@@ -167,4 +167,3 @@
           owner: root
           group: root
           state: link
-

--- a/nginx.run
+++ b/nginx.run
@@ -10,6 +10,7 @@ trap "exit 137" SIGKILL
 trap "exit 143" SIGTERM
 
 PIDFILE=/var/run/nginx.pid
+SERVER_BASE_URL=${SERVER_BASE_URL:-http://localhost}
 SERVER=$(echo ${SERVER_BASE_URL} | awk -F/ '{print $3}')
 
 # Should we be doing this this way?

--- a/nginx.run
+++ b/nginx.run
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -x
 
 source /etc/default/chnserver
 
@@ -10,7 +11,7 @@ trap "exit 137" SIGKILL
 trap "exit 143" SIGTERM
 
 PIDFILE=/var/run/nginx.pid
-SERVER_BASE_URL=${SERVER_BASE_URL:-http://localhost}
+SERVER_BASE_URL=${SERVER_BASE_URL:-http://$(curl http://httpbin.org/ip | jq -r .origin)}
 SERVER=$(echo ${SERVER_BASE_URL} | awk -F/ '{print $3}')
 
 # Should we be doing this this way?

--- a/nginx.run
+++ b/nginx.run
@@ -33,7 +33,8 @@ then
   openssl req -x509 -newkey rsa:4096 -keyout /etc/pki/tls/private/key.pem -out /etc/pki/tls/certs/cert.pem -nodes -days 1 -subj "/CN=${SERVER}"
   /usr/sbin/nginx &
   sleep 2
-  sed -ie "s/#server_name/server_name ${SERVER};/" /etc/nginx/sites-available/default
+  ## Note, -ie means inplace, suffix with 'e', '-i -e' means in-place, with no suffix, then run expression
+  sed -i -e "s/#server_name/server_name ${SERVER};/" /etc/nginx/sites-available/default
   certbot --nginx -n --register-unsafely-without-email --keep-until-expiring --agree-tos --domains ${SERVER}
   sleep 1
   pkill nginx

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -1,0 +1,30 @@
+import pytest
+import subprocess
+import testinfra
+import time
+
+# scope='session' uses the same container for all the tests;
+# scope='function' uses a new container per test function.
+@pytest.fixture(scope='session')
+def host(request):
+    # build local
+    ## TODO: Pull in previously built image from registry, if in CI
+    subprocess.check_call(['docker', 'build', '-t', 'chn-server-test', '-f',
+                           'Dockerfile-ubuntu', '.'])
+    # run a container
+    docker_id = subprocess.check_output(
+        ['docker', 'run', '-d', 'chn-server-test']).decode().strip()
+    # return a testinfra connection to the container
+    yield testinfra.get_host("docker://" + docker_id)
+    # at the end of the test suite, destroy the container
+    subprocess.check_call(['docker', 'rm', '-f', docker_id])
+
+
+def test_ports_listening(host):
+    print("Testing testing")
+    ## Sleep a few seconds until things come up
+    time.sleep(15)
+    print(host.check_output("netstat -anlpt"))
+    print(host.socket.get_listening_sockets())
+    assert host.socket("tcp://0.0.0.0:80").is_listening
+    assert host.socket("tcp://0.0.0.0:443").is_listening

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -8,6 +8,8 @@
     - runit
     - python-certbot-nginx
     - net-tools
+    - jq
+    - curl
 
   sysconfig_dir: /etc/default
 

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -7,6 +7,7 @@
     - libsqlite3-dev
     - runit
     - python-certbot-nginx
+    - net-tools
 
   sysconfig_dir: /etc/default
 


### PR DESCRIPTION
This patch will add some basic testing of the docker container using [Testinfra](https://testinfra.readthedocs.io/en/latest/).  Right now all of the tests are in the 'tests/test_default.py' file.  The only test makes sure that port 80 comes up and listens correctly.  You can run the tests locally with:

```
py.test .
```

This also in a quick fix to put in a default SERVER_BASE_URL when it is not defined.  Without that, the certificate/key generation fails