### PR TITLE
Feature pre-commit checking

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+---
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks.git
+    rev: v2.0.0
+    hooks:
+      - id: no-commit-to-branch
+
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: v1.13.0
+    hooks:
+      - id: yamllint


### PR DESCRIPTION
Unsure of if this is something everyone would want to use, but this adds support for [pre-commit](https://github.com/pre-commit/pre-commit)

Initial setup protects the master branch from commits, and runs yamllint on the YAML files.

It won't activate unless you run `pre-commit install` on your local repository