### PR TITLE
In which our hero turns off debug in the deploy scripts by default

### DIFF
--- a/scripts/deploy_dionaea.sh
+++ b/scripts/deploy_dionaea.sh
@@ -39,7 +39,7 @@ cat << EOF > dionaea.sysconfig
 #
 # This can be modified to change the default setup of the dionaea unattended installation
 
-DEBUG=true
+DEBUG=false
 
 # IP Address of the honeypot
 # Leaving this blank will default to the docker container IP

--- a/scripts/deploy_uhp.sh
+++ b/scripts/deploy_uhp.sh
@@ -24,7 +24,7 @@ cat << EOF > uhp.sysconfig
 #
 # This can be modified to change the default setup of the uhp unattended installation
 
-DEBUG=true
+DEBUG=false
 
 # IP Address of the honeypot
 # Leaving this blank will default to the docker container IP


### PR DESCRIPTION
This PR will ensure the default deploy scripts all write out sysconfig files with debug=false
Signed-off-by: Jesse Bowling <jesse.bowling@duke.edu>