### PR TITLE
Add country name as mouseover text for flag images

### DIFF
--- a/mhn/templates/ui/attacks.html
+++ b/mhn/templates/ui/attacks.html
@@ -85,7 +85,7 @@
                         <td>{{ loop.index }}</td>
                         <td>{{ at.timestamp|fdate }}</td>
                         <td>{{ get_sensor_name(at.identifier) }}</td>
-                        <td><img src="{{ get_flag_ip(at.source_ip) }}" width=25 height=50 /></td>
+                        <td><img src="{{ get_flag_ip(at.source_ip) }}" title="{{ get_country_ip(at.source_ip) }}" width=25 height=50 /></td>
                         <td>{{ at.source_ip }}</td>
                         <td>{{ at.destination_port }}</td>
                         <td>{{ at.protocol }}</td>

--- a/mhn/templates/ui/dashboard.html
+++ b/mhn/templates/ui/dashboard.html
@@ -28,7 +28,7 @@
                 <ol>
                 {% for ip in top_attackers %}
                     <li><strong>
-                    <img src="{{ get_flag_ip(ip.source_ip) }}" width=25 height=50 />
+                    <img src="{{ get_flag_ip(ip.source_ip) }}" title="{{ get_country_ip(ip.source_ip) }}" width=25 height=50 />
                     <a href="{{ url_for('ui.get_attacks', source_ip=ip.source_ip) }}">{{ ip.source_ip }} ({{ ip.count | number_format }} attacks)</a>
                     </li></strong>
                 {% endfor %}

--- a/mhn/ui/constants.py
+++ b/mhn/ui/constants.py
@@ -1,1 +1,2 @@
 DEFAULT_FLAG_URL = '/static/img/unknown.png'
+DEFAULT_COUNTRY_NAME = 'Unknown'

--- a/mhn/ui/utils.py
+++ b/mhn/ui/utils.py
@@ -9,6 +9,7 @@ import struct
 from mhn.api.models import Sensor
 
 flag_cache = SimpleCache(threshold=1000, default_timeout=300)
+country_cache = SimpleCache(threshold=1000, default_timeout=300)
 sensor_cache = SimpleCache(threshold=1000, default_timeout=300)
 
 def is_RFC1918_addr(ip):
@@ -41,6 +42,16 @@ def get_flag_ip(ipaddr):
         flag_cache.set(ipaddr, flag)
     return flag
 
+def get_country_ip(ipaddr):
+    if is_RFC1918_addr(ipaddr):
+        return constants.DEFAULT_COUNTRY_NAME
+
+    name = country_cache.get(ipaddr)
+    if not name:
+        name = _get_country_ip(ipaddr)
+        country_cache.set(ipaddr, name)
+    return name
+
 def get_sensor_name(sensor_id):
     sensor_name = sensor_cache.get(sensor_id)
     if not sensor_name:
@@ -64,6 +75,7 @@ def _get_flag_ip(ipaddr):
         # the country code for this IP address.
         r = requests.get(geo_api.format(ipaddr))
         ccode = r.json()['countryCode']
+	app.logger.warning(r.json())
     except Exception:
         app.logger.warning("Could not determine flag for ip: {}".format(ipaddr))
         return constants.DEFAULT_FLAG_URL
@@ -74,3 +86,15 @@ def _get_flag_ip(ipaddr):
             return flag
         else:
             return constants.DEFAULT_FLAG_URL
+
+def _get_country_ip(ipaddr):
+    geo_api = 'https://geospray.threatstream.com/ip/{}'
+    try:
+        # Using threatstream's geospray API to get
+        # the country name for this IP address.
+        r = requests.get(geo_api.format(ipaddr))
+        name = r.json()['countryName']
+        return name
+    except Exception:
+        app.logger.warning("Could not determine country name for ip: {}".format(ipaddr))
+        return constants.DEFAULT_COUNTRY_NAME

--- a/mhn/ui/views.py
+++ b/mhn/ui/views.py
@@ -7,7 +7,7 @@ from flask import (
 from flask_security import logout_user as logout
 from sqlalchemy import desc, func
 
-from mhn.ui.utils import get_flag_ip, get_sensor_name
+from mhn.ui.utils import get_flag_ip, get_country_ip, get_sensor_name
 from mhn.api.models import (
         Sensor, Rule, DeployScript as Script,
         RuleSource)
@@ -70,7 +70,6 @@ def dashboard():
     top_sensor = clio.session.top_sensor(top=5, hours_ago=24)
     # TOP 5 sigs
     freq_sigs = clio.hpfeed.top_sigs(top=5, hours_ago=24)
-    
     return render_template('ui/dashboard.html',
                            attackcount=attackcount,
                            top_attackers=top_attackers,
@@ -79,7 +78,8 @@ def dashboard():
                            top_sensor=top_sensor,
                            freq_sigs=freq_sigs,
                            get_sensor_name=get_sensor_name,
-                           get_flag_ip=get_flag_ip)
+                           get_flag_ip=get_flag_ip,
+                           get_country_ip=get_country_ip)
 
 
 @ui.route('/attacks/', methods=['GET'])
@@ -94,8 +94,8 @@ def get_attacks():
     sessions = mongo_pages(sessions, total, limit=10)
     return render_template('ui/attacks.html', attacks=sessions,
                            sensors=Sensor.query, view='ui.get_attacks',
-                           get_flag_ip=get_flag_ip, get_sensor_name=get_sensor_name,
-                           **request.args.to_dict())
+                           get_flag_ip=get_flag_ip, get_country_ip=get_country_ip,
+                           get_sensor_name=get_sensor_name, **request.args.to_dict())
 
 
 @ui.route('/feeds/', methods=['GET'])


### PR DESCRIPTION
Foreign relations is not my strong suit.  This PR adds a mouseover title for the flags that contains the full country name (and also starts me getting familiar with the codebase).

<img width="467" alt="chn-dashboard-with-flag-patch" src="https://user-images.githubusercontent.com/208126/57655668-10e06480-759c-11e9-860c-17c8a299e773.png">


