### PR TITLE
Issue 118 remove vestigial menu items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 TODO
 *.swp
 .pytest_cache/
+*.pyc
+
+mhn/static/mhn.rules
+storage/
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,39 @@
 version: '2'
 services:
-  ubuntu:
+  mongodb:
+    image: stingar/mongodb:1.7
+    volumes:
+      - ./storage/mongodb:/var/lib/mongo:z
+  redis:
+    image: stingar/redis:1.7
+    volumes:
+      - ./storage/redis:/var/lib/redis:z
+  hpfeeds:
+    image: stingar/hpfeeds:1.7
+    links:
+      - mongodb:mongodb
+    ports:
+      - "10000:10000"
+  mnemosyne:
+    image: stingar/mnemosyne:1.7
+    links:
+      - mongodb:mongodb
+      - hpfeeds:hpfeeds
+  chnserver:
     build:
       context: .
-    image: chnserver:ubuntu
-    ports:
-      - "127.0.0.1:80:80"
-      - "127.0.0.1:443:443"
     env_file:
       - .development.env
+    volumes:
+      - ./config/collector:/etc/collector:z
+      - ./storage/chnserver/sqlite:/opt/sqlite:z
+      - ./chnserver.sysconfig:/etc/default/chnserver:z
+      - ./certs:/etc/letsencrypt:z
+      - ./mhn:/opt/mhn:z
+    links:
+      - mongodb:mongodb
+      - redis:redis
+      - hpfeeds:hpfeeds
+    ports:
+      - "80:80"
+      - "443:443"

--- a/mhn/common/clio.py
+++ b/mhn/common/clio.py
@@ -397,10 +397,8 @@ class HpFeed(ResourceMixin):
     expected_filters = ('ident', 'channel', 'payload', '_id', 'timestamp', )
 
     channel_map = {
-        'snort.alerts': ['date', 'sensor', 'source_ip', 'destination_port', 'priority', 'classification', 'signature'],
         'dionaea.capture': ['url', 'daddr', 'saddr', 'dport', 'sport', 'sha512', 'md5'],
         'glastopf.events': ['time', 'pattern', 'filename', 'source', 'request_url'],
-        'suricata.events': ['timestamp', 'sensor', 'source_ip', 'destination_port', 'proto', 'signature'],
     }
 
     def json_payload(self, data):

--- a/mhn/templates/base.html
+++ b/mhn/templates/base.html
@@ -22,7 +22,7 @@
                 <ul class="left">
                     <li><a href="{{ url_for('ui.deploy_mgmt') }}">Deploy</a></li>
                     <li><a href="{{ url_for('ui.get_attacks') }}">Attacks</a></li>
-                    <li><a href="{{ url_for('ui.get_feeds', channel='snort.alerts') }}">Payloads</a></li>
+                    <li><a href="{{ url_for('ui.get_feeds', channel='dionaea.capture') }}">Payloads</a></li>
                     <li class="has-dropdown">
                         <a href="{{ url_for('ui.get_sensors') }}">Sensors</a>
                         <ul class="dropdown">

--- a/mhn/templates/base.html
+++ b/mhn/templates/base.html
@@ -20,21 +20,9 @@
             <section class="top-bar-section">
                 <!-- Left Nav Section -->
                 <ul class="left">
-                    <li><a href="{{ url_for('ui.honeymap') }}">Map</a></li>
                     <li><a href="{{ url_for('ui.deploy_mgmt') }}">Deploy</a></li>
                     <li><a href="{{ url_for('ui.get_attacks') }}">Attacks</a></li>
                     <li><a href="{{ url_for('ui.get_feeds', channel='snort.alerts') }}">Payloads</a></li>
-                    <li class="has-dropdown">
-                        <a href="{{ url_for('ui.get_rules') }}">Rules</a>
-                        <ul class="dropdown">
-                            <li><label>Manage</label></li>
-                            <li><a href="{{ url_for('ui.get_rules') }}">Activate/Deactivate</a></li>
-                            <li><a href="{{ url_for('ui.rule_sources_mgmt') }}">Sources</a></li>
-                            <li><label>Download</label></li>
-                            <li><a href="{{ url_for('api.get_rules', plaintext=true) }}">Live Render</a></li>
-                            <li><a href="/static/mhn.rules">Pre-Rendered</a></li>
-                        </ul>
-                    </li>
                     <li class="has-dropdown">
                         <a href="{{ url_for('ui.get_sensors') }}">Sensors</a>
                         <ul class="dropdown">

--- a/mhn/templates/ui/dashboard.html
+++ b/mhn/templates/ui/dashboard.html
@@ -83,22 +83,7 @@
                 </ol>
             </div>
         </div>
-        <div class="row" style="margin-top:30px;">
-            <div class="small-6 columns">
-                <h3>TOP 5 Attacks Signatures:</h3>
-            </div>
-        </div>
-        <div class="row">
-            <div class="small-10 push-2 columns">
-                <ol>
-                {% for sig in freq_sigs %}
-                    <li><strong>
-                    <a href="{{ url_for('ui.get_feeds', payload=sig['signature'], channel='snort.alerts') }}">{{ sig['signature'] }} ({{ sig['count'] | number_format }} times)</a>
-                    </li></strong>
-                {% endfor %}
-                </ol>
-            </div>
-        </div>
+
     </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
This pull request should accomplish the following:
1) remove map and rules menu options
2) remove 'top 5 attack signatures' from dashboard
3) remove 'suricata.alerts' and 'snort.alerts' from payload search
To test those, one would just run the app and make sure they are gone

In addition, while trying to create a development environment I added these (with Jim's help):
1) a more complete docker-compose file for local dev
2) a few more entries in .gitignore to ignore files generated during the run process
To test this, one would just run > docker-compose up and see if it runs.  There will be no data, but the application should run.


