### PR TITLE
Custom scripts persistence

### DIFF
--- a/initdatabase.py
+++ b/initdatabase.py
@@ -1,4 +1,4 @@
-from mhn import create_clean_db, reload_scripts
+from mhn import create_clean_db, reload_scripts, load_custom_scripts
 from mhn import mhn, db
 from sqlalchemy import create_engine
 from sqlalchemy import inspect
@@ -11,10 +11,12 @@ def init_database():
         if 'user' in inspector.get_table_names():
             print("Database already initialized")
             reload_scripts()
+            load_custom_scripts()
             sys.exit()
         else:
             print("Initializing new database")
             create_clean_db()
+            load_custom_scripts()
 
 
 if __name__ == '__main__':

--- a/initdatabase.py
+++ b/initdatabase.py
@@ -1,4 +1,4 @@
-from mhn import create_clean_db, reload_scripts, load_custom_scripts
+from mhn import create_clean_db, reload_scripts
 from mhn import mhn, db
 from sqlalchemy import create_engine
 from sqlalchemy import inspect

--- a/initdatabase.py
+++ b/initdatabase.py
@@ -11,13 +11,10 @@ def init_database():
         if 'user' in inspector.get_table_names():
             print("Database already initialized")
             reload_scripts()
-            load_custom_scripts()
             sys.exit()
         else:
             print("Initializing new database")
             create_clean_db()
-            load_custom_scripts()
-
 
 if __name__ == '__main__':
     init_database()

--- a/mhn/__init__.py
+++ b/mhn/__init__.py
@@ -172,13 +172,13 @@ def create_clean_db():
 
 def pretty_name(name):
     # remove trailing suffix
-    nosuffix = os.path.splittext(name)[0]
+    nosuffix = os.path.splitext(name)[0]
 
     # remove special characters
     nospecial = re.sub('[\'";&%#@!()*]*', '', nosuffix)
 
     # Convert underscore to space
-    underspace = re.sub('[_]*', ' ', nospecial)
+    underspace = re.sub('_', ' ', nospecial)
 
     return underspace
 

--- a/mhn/__init__.py
+++ b/mhn/__init__.py
@@ -167,44 +167,16 @@ def create_clean_db():
             # skip fetching sources on initial database population
             # fetch_sources()
 
-def load_custom_scripts():
-    from os import path
-    from os.path import isfile
-    from mhn.api.models import DeployScript
-    from os import walk
-    import re
-
-    superuser = user_datastore.get_user(mhn.config.get('SUPERUSER_EMAIL'))
-    deployscripts = {}
-    custom_path = './custom_scripts/'
-
-    f = []
-    for (dirpath, dirnames, filenames) in walk(custom_path):
-        f.extend(filenames)
-        break
-    for fname in f:
-        p = path.abspath(custom_path + fname)
-        if isfile(p):
-            n = re.sub('[\'";&%#@!()*]*','',path.basename(p))
-            deployscripts[n] = p
-
-    db.session.query(DeployScript).delete()
-    for honeypot, deploypath in deployscripts.items():
-        with open(deploypath, 'r') as deployfile:
-            initdeploy = DeployScript()
-            initdeploy.script = deployfile.read()
-            initdeploy.notes = 'Initial deploy script for {}'.format(honeypot)
-            initdeploy.user = superuser
-            initdeploy.name = honeypot
-            db.session.add(initdeploy)
-            db.session.commit()
-
 
 def reload_scripts():
     from os import path
+    from os.path import isfile
+    from os import walk
     from mhn.api.models import DeployScript
+    import re
 
     superuser = user_datastore.get_user(mhn.config.get('SUPERUSER_EMAIL'))
+    custom_path = './custom_scripts/'
 
     deployscripts = {
         'Ubuntu - Conpot': path.abspath('./scripts/deploy_conpot.sh'),
@@ -216,6 +188,16 @@ def reload_scripts():
         'Ubuntu - RDPHoney': path.abspath('./scripts/deploy_rdphoney.sh'),
         'Ubuntu - UHP': path.abspath('./scripts/deploy_uhp.sh'),
     }
+
+    f = []
+    for (dirpath, dirnames, filenames) in walk(custom_path):
+        f.extend(filenames)
+        break
+    for fname in f:
+        p = path.abspath(custom_path + fname)
+        if isfile(p):
+            n = re.sub('[\'";&%#@!()*]*','',path.basename(p))
+            deployscripts[n] = p
 
     db.session.query(DeployScript).delete()
     for honeypot, deploypath in deployscripts.items():


### PR DESCRIPTION
This PR adds a feature allowing users to provide a directory of custom deployment scripts that will become available in CHN upon container restart.

Some consolidation of python import statements was also done, as importing in mid-function seems barbaric. 