### PR TITLE
add sudo elsewhere within "deploy command"

### DIFF
--- a/mhn/templates/ui/script.html
+++ b/mhn/templates/ui/script.html
@@ -31,8 +31,8 @@
         </div>
         <div class="row">
             <div class="small-12 small-centered columns">
-                <p><kbd>wget "{{ settings.server_url }}/api/script/?text=true&script_id={{ script.id }}" -O deploy.sh &&
-                    sudo bash deploy.sh {{ settings.server_url }} {{ settings.deploy_key }} {{ arch }} && docker-compose up -d</kbd>
+                <p><kbd>sudo wget "{{ settings.server_url }}/api/script/?text=true&script_id={{ script.id }}" -O deploy.sh &&
+                    sudo bash deploy.sh {{ settings.server_url }} {{ settings.deploy_key }} {{ arch }} && sudo docker-compose up -d</kbd>
                 </p>
             </div>
         </div>


### PR DESCRIPTION
sudo was already present to run deploy.sh; I also added sudo prior to wget and docker-compose cmds in the event (1) cmd is run from a dir where permissions are restricted and (2) I think docker/docker-compose don't work without elevated permissions