### PR TITLE
fix change password button in webUI not working

### DIFF
--- a/mhn/auth/views.py
+++ b/mhn/auth/views.py
@@ -124,7 +124,7 @@ def change_passwd():
     if password != password_repeat:
         # Password do not match.
         return error_response(errors.AUTH_PASSWD_MATCH, 400)
-    if current_user.is_authenticated():
+    if current_user.is_authenticated:
         # No need to check password hash object or email.
         user = current_user
     else:


### PR DESCRIPTION
current_user.is_authenticated is apparently a boolean property rather than a function that returns a boolean. Have to remove the parens for the "change password" button under Settings in the webUI to work.