### PR TITLE
In which our hero uses fancy braces expansion 

### DIFF
--- a/nginx.run
+++ b/nginx.run
@@ -13,6 +13,7 @@ trap "exit 143" SIGTERM
 PIDFILE=/var/run/nginx.pid
 SERVER_BASE_URL=${SERVER_BASE_URL:-http://$(curl http://httpbin.org/ip | jq -r .origin)}
 SERVER=$(echo ${SERVER_BASE_URL} | awk -F/ '{print $3}')
+SERVER="${SERVER%%:*}"
 
 # Should we be doing this this way?
 # What should we do to cleanup in a container?


### PR DESCRIPTION
to remove port specification from the SERVER variable used for certbot bootstrap. Fix for #137 

Signed-off-by: Jesse Bowling <jesse.bowling@duke.edu>