### PR TITLE
add required capability to default dionaea deploy

### DIFF
--- a/scripts/deploy_dionaea.sh
+++ b/scripts/deploy_dionaea.sh
@@ -35,6 +35,8 @@ services:
       - "27017:27017"
     env_file:
       - dionaea.env
+    cap_add:
+      - NET_ADMIN
 volumes:
     configs:
 EOF


### PR DESCRIPTION
Due to an issue in dionaea, the NET_ADMIN capability is required to avoid 100% CPU usage