### PR TITLE
CHN-Server modernization - Phase 1:

### DIFF
--- a/mhn/auth/views.py
+++ b/mhn/auth/views.py
@@ -6,7 +6,7 @@ from flask_mail import Message
 from sqlalchemy.exc import IntegrityError
 from flask_security.utils import (
         login_user as login, verify_and_update_password,
-        encrypt_password, logout_user as logout)
+        hash_password as encrypt_password, logout_user as logout)
 
 from mhn import db, mail
 from mhn import user_datastore

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,22 +1,27 @@
-argparse==1.2.1
-Flask==1.0.2
-Flask-Login==0.3.0
-Flask-Mail==0.9.1
-Flask-Migrate==2.3.1
-Flask-SQLAlchemy==2.3.1
-Flask-Security==3.0.0
-Flask-Testing==0.4.2
-Flask-WTF==0.13.1
-werkzeug==0.16.0
-Flask-Script
-bcrypt
-python-dateutil==2.2
-requests>=2.20.0
-xmltodict==0.9.0
-uWSGI==2.0.14
-pymongo==2.7.2
+# Phase 1: Core Flask/Werkzeug modernization
+Flask==3.1.0
+Werkzeug==3.1.3
+Flask-Login==0.6.3
+Flask-Mail==0.10.0
+Flask-Migrate==4.0.7
+Flask-SQLAlchemy==3.1.1
+Flask-Security-Too==5.4.3
+Flask-Testing==0.8.1
+Flask-WTF==1.2.1
+WTForms==3.1.2
+
+# Phase 1: Security and compatibility updates  
+bcrypt>=3.2.0
+python-dateutil==2.9.0.post0
+requests>=2.32.0
+uWSGI==2.0.28
+
+# Phase 1: Maintain existing functionality (to be updated in later phases)
+xmltodict==0.13.0
+pymongo==4.10.1
+pygal==3.0.5
+validators>=0.34.0
+
+# Deprecated - will remove in Phase 2
 hpfeeds-threatstream==1.0
-pygal==1.7.0
 GeoIP==1.3.2
-validators>=0.12.6
-wtforms[email]==2.3.1

--- a/venv.sh
+++ b/venv.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Setup dependencies in a venv
+python3 -m venv venv && source venv/bin/activate && pip install -r requirements.txt


### PR DESCRIPTION
Updates:
  - Werkzeug: 0.16.0 -> 3.1.3
  - pymongo: 2.7.2 > 4.10.1
  - Flask: 1.0.2 -> 3.1.0
  - Flask-SQLAlchemy: 2.3.1 -> 3.1.1
  - Flask-Security: Migrated to Flask-Security-Too 5.4.3

Fixes:
  1. Replaced deprecated werkzeug.contrib.atom with custom AtomFeed class
  2. Updated authentication patterns: current_user.is_authenticated()  current_user.is_authenticated
  3. Fixed Flask-Security imports: Updated encrypt_password -> hash_password
  4. Removed deprecated argparse dependency